### PR TITLE
feat(terminal): per-card config panel (shell, font, theme, CWD, follow path)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 .DS_Store
 *.local
 .changeset/*.md
+*.tsbuildinfo

--- a/package-lock.json
+++ b/package-lock.json
@@ -2407,6 +2407,42 @@
         "@xterm/xterm": "^5.0.0"
       }
     },
+    "node_modules/@xterm/addon-image": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-image/-/addon-image-0.8.0.tgz",
+      "integrity": "sha512-b/dqpFn3jUad2pUP5UpF4scPIh0WdxRQL/1qyiahGfUI85XZTCXo0py9G6AcOR2QYUw8eJ8EowGspT7BQcgw6A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.2.0"
+      }
+    },
+    "node_modules/@xterm/addon-search": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-search/-/addon-search-0.15.0.tgz",
+      "integrity": "sha512-ZBZKLQ+EuKE83CqCmSSz5y1tx+aNOCUaA7dm6emgOX+8J9H1FWXZyrKfzjwzV+V14TV3xToz1goIeRhXBS5qjg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
+      }
+    },
+    "node_modules/@xterm/addon-unicode11": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-unicode11/-/addon-unicode11-0.8.0.tgz",
+      "integrity": "sha512-LxinXu8SC4OmVa6FhgwsVCBZbr8WoSGzBl2+vqe8WcQ6hb1r6Gj9P99qTNdPiFPh4Ceiu2pC8xukZ6+2nnh49Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
+      }
+    },
+    "node_modules/@xterm/addon-web-links": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-web-links/-/addon-web-links-0.11.0.tgz",
+      "integrity": "sha512-nIHQ38pQI+a5kXnRaTgwqSHnX7KE6+4SVoceompgHL26unAxdfP6IPqUTSYPQgSwM56hsElfoNrrW5V7BUED/Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
+      }
+    },
     "node_modules/@xterm/addon-webgl": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-webgl/-/addon-webgl-0.18.0.tgz",
@@ -4967,7 +5003,7 @@
     },
     "packages/api": {
       "name": "@origin-cards/api",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "devDependencies": {
         "tsup": "^8.0.0",
         "typescript": "~5.7.2"
@@ -5100,12 +5136,17 @@
         "@origin-cards/sdk": "*",
         "@xterm/addon-clipboard": "^0.1.0",
         "@xterm/addon-fit": "^0.10.0",
+        "@xterm/addon-image": "^0.8.0",
+        "@xterm/addon-search": "^0.15.0",
+        "@xterm/addon-unicode11": "^0.8.0",
+        "@xterm/addon-web-links": "^0.11.0",
         "@xterm/addon-webgl": "^0.18.0",
         "@xterm/xterm": "^5.5.0"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "*",
         "react": "*",
+        "react-dom": "^19.2.4",
         "typescript": "*",
         "vite": "*"
       }

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -10,14 +10,19 @@
   "dependencies": {
     "@origin-cards/api": "*",
     "@origin-cards/sdk": "*",
-    "@xterm/xterm": "^5.5.0",
+    "@xterm/addon-clipboard": "^0.1.0",
     "@xterm/addon-fit": "^0.10.0",
+    "@xterm/addon-image": "^0.8.0",
+    "@xterm/addon-search": "^0.15.0",
+    "@xterm/addon-unicode11": "^0.8.0",
+    "@xterm/addon-web-links": "^0.11.0",
     "@xterm/addon-webgl": "^0.18.0",
-    "@xterm/addon-clipboard": "^0.1.0"
+    "@xterm/xterm": "^5.5.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "*",
     "react": "*",
+    "react-dom": "^19.2.4",
     "typescript": "*",
     "vite": "*"
   }

--- a/packages/terminal/src/TerminalConfigPanel.tsx
+++ b/packages/terminal/src/TerminalConfigPanel.tsx
@@ -1,0 +1,259 @@
+import { useEffect, useState } from "react";
+import type { TerminalConfig } from "./config";
+import { DEFAULTS } from "./config";
+import { detectShells } from "./shells";
+
+interface Props {
+  config: TerminalConfig;
+  isDark: boolean;
+  onUpdate: (patch: Partial<TerminalConfig>) => void;
+  onRestart: () => void;
+  onClose: () => void;
+}
+
+export default function TerminalConfigPanel({ config, isDark, onUpdate, onRestart, onClose }: Props) {
+  const [shells, setShells] = useState<string[]>([]);
+
+  useEffect(() => {
+    detectShells().then(setShells).catch(() => setShells(["/bin/zsh", "/bin/bash", "/bin/sh"]));
+  }, []);
+
+  // ---------------------------------------------------------------------------
+  // Styles — inline to avoid requiring Tailwind / external CSS in the terminal
+  // plugin. Colours adapt to isDark.
+  // ---------------------------------------------------------------------------
+  const bg = isDark ? "#252526" : "#f3f3f3";
+  const fg = isDark ? "#cccccc" : "#333333";
+  const border = isDark ? "#3c3c3c" : "#d4d4d4";
+  const inputBg = isDark ? "#1e1e1e" : "#ffffff";
+  const inputBorder = isDark ? "#555" : "#bbb";
+  const hoverBg = isDark ? "#2a2d2e" : "#e8e8e8";
+
+  const panelStyle: React.CSSProperties = {
+    position: "absolute",
+    top: 0,
+    right: 0,
+    width: 280,
+    height: "100%",
+    background: bg,
+    color: fg,
+    borderLeft: `1px solid ${border}`,
+    display: "flex",
+    flexDirection: "column",
+    fontSize: 12,
+    fontFamily: "system-ui, -apple-system, sans-serif",
+    zIndex: 100,
+    overflow: "auto",
+  };
+
+  const headerStyle: React.CSSProperties = {
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+    padding: "8px 12px",
+    borderBottom: `1px solid ${border}`,
+    fontWeight: 600,
+    fontSize: 13,
+  };
+
+  const sectionStyle: React.CSSProperties = {
+    padding: "8px 12px",
+    display: "flex",
+    flexDirection: "column",
+    gap: 10,
+  };
+
+  const labelStyle: React.CSSProperties = {
+    display: "flex",
+    flexDirection: "column",
+    gap: 3,
+  };
+
+  const labelTextStyle: React.CSSProperties = {
+    fontWeight: 500,
+    fontSize: 11,
+    textTransform: "uppercase",
+    letterSpacing: "0.04em",
+    opacity: 0.7,
+  };
+
+  const inputStyle: React.CSSProperties = {
+    background: inputBg,
+    color: fg,
+    border: `1px solid ${inputBorder}`,
+    borderRadius: 3,
+    padding: "4px 6px",
+    fontSize: 12,
+    outline: "none",
+    fontFamily: "inherit",
+  };
+
+  const selectStyle: React.CSSProperties = {
+    ...inputStyle,
+    cursor: "pointer",
+  };
+
+  const checkboxRowStyle: React.CSSProperties = {
+    display: "flex",
+    alignItems: "center",
+    gap: 6,
+  };
+
+  const btnStyle: React.CSSProperties = {
+    background: isDark ? "#0e639c" : "#007acc",
+    color: "#fff",
+    border: "none",
+    borderRadius: 3,
+    padding: "5px 10px",
+    fontSize: 12,
+    cursor: "pointer",
+    fontFamily: "inherit",
+  };
+
+  const closeBtnStyle: React.CSSProperties = {
+    background: "none",
+    border: "none",
+    color: fg,
+    cursor: "pointer",
+    fontSize: 16,
+    lineHeight: 1,
+    padding: "2px 4px",
+    borderRadius: 3,
+  };
+
+  const shellValue = config.shell || "(system default)";
+
+  return (
+    <div style={panelStyle}>
+      <div style={headerStyle}>
+        <span>Terminal Settings</span>
+        <button
+          style={closeBtnStyle}
+          onClick={onClose}
+          title="Close settings"
+          aria-label="Close settings"
+          onMouseEnter={(e) => (e.currentTarget.style.background = hoverBg)}
+          onMouseLeave={(e) => (e.currentTarget.style.background = "none")}
+        >
+          ✕
+        </button>
+      </div>
+
+      <div style={sectionStyle}>
+        {/* Shell */}
+        <label style={labelStyle}>
+          <span style={labelTextStyle}>Shell</span>
+          <select
+            style={selectStyle}
+            value={config.shell}
+            onChange={(e) => onUpdate({ shell: e.target.value })}
+          >
+            <option value="">System default</option>
+            {shells.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        {/* Font Size */}
+        <label style={labelStyle}>
+          <span style={labelTextStyle}>Font Size</span>
+          <input
+            type="number"
+            style={inputStyle}
+            min={8}
+            max={32}
+            value={config.fontSize}
+            onChange={(e) => {
+              const v = parseInt(e.target.value, 10);
+              if (v >= 8 && v <= 32) onUpdate({ fontSize: v });
+            }}
+          />
+        </label>
+
+        {/* Font Family */}
+        <label style={labelStyle}>
+          <span style={labelTextStyle}>Font Family</span>
+          <input
+            type="text"
+            style={inputStyle}
+            value={config.fontFamily}
+            onChange={(e) => onUpdate({ fontFamily: e.target.value })}
+          />
+        </label>
+
+        {/* Theme */}
+        <label style={labelStyle}>
+          <span style={labelTextStyle}>Theme</span>
+          <select
+            style={selectStyle}
+            value={config.theme}
+            onChange={(e) => onUpdate({ theme: e.target.value as TerminalConfig["theme"] })}
+          >
+            <option value="app">Follow app theme</option>
+            <option value="dark">Dark</option>
+            <option value="light">Light</option>
+            <option value="custom">Custom</option>
+          </select>
+        </label>
+
+        {/* Starting Directory */}
+        <label style={labelStyle}>
+          <span style={labelTextStyle}>Starting Directory</span>
+          <input
+            type="text"
+            style={inputStyle}
+            value={config.startingDir}
+            placeholder="workspace"
+            onChange={(e) => onUpdate({ startingDir: e.target.value || "workspace" })}
+          />
+          <span style={{ fontSize: 10, opacity: 0.5 }}>
+            Use &quot;workspace&quot; for the workspace root, or an absolute path.
+          </span>
+        </label>
+
+        {/* Follow Active Path */}
+        <label style={checkboxRowStyle}>
+          <input
+            type="checkbox"
+            checked={config.followActivePath}
+            onChange={(e) => onUpdate({ followActivePath: e.target.checked })}
+          />
+          <span>Follow active path</span>
+        </label>
+        <span style={{ fontSize: 10, opacity: 0.5, marginTop: -6 }}>
+          Auto-cd when the workspace active file changes.
+        </span>
+
+        {/* Scrollback Lines */}
+        <label style={labelStyle}>
+          <span style={labelTextStyle}>Scrollback Lines</span>
+          <input
+            type="number"
+            style={inputStyle}
+            min={500}
+            max={100_000}
+            step={500}
+            value={config.scrollbackLines}
+            onChange={(e) => {
+              const v = parseInt(e.target.value, 10);
+              if (v >= 500 && v <= 100_000) onUpdate({ scrollbackLines: v });
+            }}
+          />
+        </label>
+
+        {/* Restart button */}
+        <div style={{ marginTop: 8, display: "flex", gap: 8 }}>
+          <button style={btnStyle} onClick={onRestart}>
+            Restart Terminal
+          </button>
+        </div>
+        <span style={{ fontSize: 10, opacity: 0.5 }}>
+          Shell and starting directory changes take effect on restart.
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/packages/terminal/src/TerminalPlugin.tsx
+++ b/packages/terminal/src/TerminalPlugin.tsx
@@ -17,6 +17,10 @@ import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { ClipboardAddon } from "@xterm/addon-clipboard";
+import { WebLinksAddon } from "@xterm/addon-web-links";
+import { SearchAddon } from "@xterm/addon-search";
+import { Unicode11Addon } from "@xterm/addon-unicode11";
+import { ImageAddon } from "@xterm/addon-image";
 import "@xterm/xterm/css/xterm.css";
 
 export default function TerminalPlugin({ context }: { context: IframePluginContextWithConfig }) {
@@ -31,12 +35,25 @@ export default function TerminalPlugin({ context }: { context: IframePluginConte
       fontSize: 13,
       theme: { background: "#1e1e1e" },
       cursorBlink: true,
+      scrollback: 10_000,
     });
 
     const fitAddon = new FitAddon();
     const clipboardAddon = new ClipboardAddon();
+    const webLinksAddon = new WebLinksAddon();
+    const searchAddon = new SearchAddon();
+    const unicode11Addon = new Unicode11Addon();
+    const imageAddon = new ImageAddon();
+
     term.loadAddon(fitAddon);
     term.loadAddon(clipboardAddon);
+    term.loadAddon(webLinksAddon);
+    term.loadAddon(searchAddon);
+    term.loadAddon(unicode11Addon);
+    term.loadAddon(imageAddon);
+
+    // Activate Unicode 11 for proper wide-char / emoji rendering.
+    term.unicode.activeVersion = "11";
 
     const webglAddon = new WebglAddon();
     webglAddon.onContextLoss(() => webglAddon.dispose());
@@ -67,6 +84,9 @@ export default function TerminalPlugin({ context }: { context: IframePluginConte
       id: context.cardId,
       cols,
       rows,
+      env: {
+        TERM_PROGRAM_VERSION: "0.1.0",
+      },
     }).catch(console.error);
 
     let resizeTimer: ReturnType<typeof setTimeout> | null = null;

--- a/packages/terminal/src/TerminalPlugin.tsx
+++ b/packages/terminal/src/TerminalPlugin.tsx
@@ -10,8 +10,8 @@
 //     in origin/; when it is, this plugin will receive live PTY output without
 //     any changes here.
 
-import { useEffect, useRef } from "react";
-import { invoke, onEvent } from "@origin-cards/sdk";
+import { useEffect, useRef, useState, useCallback } from "react";
+import { invoke, onEvent, useBusChannel } from "@origin-cards/sdk";
 import type { IframePluginContextWithConfig } from "@origin-cards/sdk";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
@@ -23,19 +23,56 @@ import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { ImageAddon } from "@xterm/addon-image";
 import "@xterm/xterm/css/xterm.css";
 
+import { resolveConfig, resolveXtermTheme, resolveBackground } from "./config";
+import type { TerminalConfig } from "./config";
+import TerminalConfigPanel from "./TerminalConfigPanel";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Extract the parent directory from a path. */
+function dirname(path: string): string {
+  const sep = path.includes("\\") ? "\\" : "/";
+  const parts = path.split(sep);
+  parts.pop();
+  return parts.join(sep) || sep;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
 export default function TerminalPlugin({ context }: { context: IframePluginContextWithConfig }) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const termRef = useRef<Terminal | null>(null);
+  const fitAddonRef = useRef<FitAddon | null>(null);
 
+  const [configOpen, setConfigOpen] = useState(false);
+  const [restartKey, setRestartKey] = useState(0);
+
+  // Resolve typed config from the raw context.config record.
+  const config = resolveConfig(context.config);
+  const configRef = useRef(config);
+  configRef.current = config;
+
+  // ------------------------------------------------------------------
+  // Terminal lifecycle — create / destroy
+  // Depends on cardId + restartKey so the user can restart the PTY.
+  // ------------------------------------------------------------------
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
 
+    const cfg = configRef.current;
+    const xtermTheme = resolveXtermTheme(cfg.theme, context.theme);
+
     const term = new Terminal({
-      fontFamily: "monospace",
-      fontSize: 13,
-      theme: { background: "#1e1e1e" },
+      fontFamily: cfg.fontFamily,
+      fontSize: cfg.fontSize,
+      theme: xtermTheme,
       cursorBlink: true,
-      scrollback: 10_000,
+      scrollback: cfg.scrollbackLines,
     });
 
     const fitAddon = new FitAddon();
@@ -62,10 +99,12 @@ export default function TerminalPlugin({ context }: { context: IframePluginConte
     term.open(container);
     fitAddon.fit();
 
+    termRef.current = term;
+    fitAddonRef.current = fitAddon;
+
     const { cols, rows } = term;
 
     // Subscribe to PTY data stream via the SDK event bridge.
-    // The host proxies pty:data events from the Rust PTY channel.
     const unsubPty = onEvent("pty:data", { id: context.cardId }, (payload) => {
       const data = (payload as { data: number[] }).data;
       term.write(new Uint8Array(data));
@@ -78,12 +117,15 @@ export default function TerminalPlugin({ context }: { context: IframePluginConte
       }).catch(console.error);
     });
 
-    // pty_spawn no longer receives a Channel object — PTY data arrives via
-    // the ORIGIN_EVENT bridge subscribed above.
+    // Resolve starting directory.
+    const cwd = cfg.startingDir === "workspace" ? context.workspacePath : cfg.startingDir;
+
     invoke("pty_spawn", {
       id: context.cardId,
       cols,
       rows,
+      ...(cfg.shell ? { shell: cfg.shell } : {}),
+      cwd,
       env: {
         TERM_PROGRAM_VERSION: "0.1.0",
       },
@@ -107,12 +149,137 @@ export default function TerminalPlugin({ context }: { context: IframePluginConte
       if (resizeTimer) clearTimeout(resizeTimer);
       ro.disconnect();
       unsubPty();
+      termRef.current = null;
+      fitAddonRef.current = null;
       term.dispose();
       invoke("pty_destroy", { id: context.cardId }).catch(console.error);
     };
-  }, [context.cardId]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [context.cardId, restartKey]);
+
+  // ------------------------------------------------------------------
+  // Dynamic option updates (no PTY restart required)
+  // ------------------------------------------------------------------
+
+  // Font size
+  useEffect(() => {
+    const term = termRef.current;
+    if (!term) return;
+    term.options.fontSize = config.fontSize;
+    fitAddonRef.current?.fit();
+  }, [config.fontSize]);
+
+  // Font family
+  useEffect(() => {
+    const term = termRef.current;
+    if (!term) return;
+    term.options.fontFamily = config.fontFamily;
+    fitAddonRef.current?.fit();
+  }, [config.fontFamily]);
+
+  // Theme
+  useEffect(() => {
+    const term = termRef.current;
+    if (!term) return;
+    term.options.theme = resolveXtermTheme(config.theme, context.theme);
+  }, [config.theme, context.theme]);
+
+  // Scrollback
+  useEffect(() => {
+    const term = termRef.current;
+    if (!term) return;
+    term.options.scrollback = config.scrollbackLines;
+  }, [config.scrollbackLines]);
+
+  // ------------------------------------------------------------------
+  // Follow active path
+  // ------------------------------------------------------------------
+
+  const followRef = useRef(config.followActivePath);
+  followRef.current = config.followActivePath;
+
+  const handleActivePath = useCallback(
+    (payload: unknown) => {
+      if (!followRef.current) return;
+      const { path, type } = payload as { path: string; type: "file" | "directory" };
+      const dir = type === "directory" ? path : dirname(path);
+      // Escape single quotes in the path for safe shell interpolation.
+      const escaped = dir.replace(/'/g, "'\\''");
+      invoke("pty_write", {
+        id: context.cardId,
+        data: Array.from(new TextEncoder().encode(`cd '${escaped}'\r`)),
+      }).catch(console.error);
+    },
+    [context.cardId],
+  );
+
+  useBusChannel("origin:workspace/active-path", handleActivePath);
+
+  // ------------------------------------------------------------------
+  // Config panel callbacks
+  // ------------------------------------------------------------------
+
+  const handleConfigUpdate = useCallback(
+    (patch: Partial<TerminalConfig>) => {
+      context.setConfig(patch as Record<string, unknown>);
+    },
+    [context],
+  );
+
+  const handleRestart = useCallback(() => {
+    setRestartKey((k) => k + 1);
+  }, []);
+
+  const handleCloseConfig = useCallback(() => {
+    setConfigOpen(false);
+  }, []);
+
+  // ------------------------------------------------------------------
+  // Resolve background for the container div (keeps it in sync with theme).
+  // ------------------------------------------------------------------
+
+  const bg = resolveBackground(config.theme, context.theme);
 
   return (
-    <div ref={containerRef} style={{ width: "100%", height: "100%", background: "#1e1e1e" }} />
+    <div style={{ position: "relative", width: "100%", height: "100%" }}>
+      <div ref={containerRef} style={{ width: "100%", height: "100%", background: bg }} />
+
+      {/* Gear icon — toggle config panel */}
+      <button
+        onClick={() => setConfigOpen((o) => !o)}
+        title="Terminal settings"
+        aria-label="Terminal settings"
+        style={{
+          position: "absolute",
+          top: 4,
+          right: configOpen ? 286 : 6,
+          zIndex: 101,
+          background: "rgba(128,128,128,0.25)",
+          border: "none",
+          borderRadius: 4,
+          color: "#ccc",
+          cursor: "pointer",
+          fontSize: 15,
+          lineHeight: 1,
+          padding: "3px 5px",
+          transition: "right 0.15s ease, opacity 0.15s ease",
+          opacity: 0.5,
+        }}
+        onMouseEnter={(e) => (e.currentTarget.style.opacity = "1")}
+        onMouseLeave={(e) => (e.currentTarget.style.opacity = "0.5")}
+      >
+        ⚙
+      </button>
+
+      {configOpen && (
+        <TerminalConfigPanel
+          config={config}
+          isDark={resolveBackground(config.theme, context.theme) !== "#ffffff"}
+          onUpdate={handleConfigUpdate}
+          onRestart={handleRestart}
+          onClose={handleCloseConfig}
+        />
+      )}
+    </div>
   );
 }

--- a/packages/terminal/src/config.ts
+++ b/packages/terminal/src/config.ts
@@ -1,0 +1,87 @@
+import type { ITheme } from "@xterm/xterm";
+
+/** Per-card terminal configuration persisted to context.config. */
+export interface TerminalConfig {
+  shell: string; // default: "" (system default — $SHELL or /bin/zsh)
+  fontSize: number; // default: 13
+  fontFamily: string; // default: "monospace"
+  theme: "app" | "dark" | "light" | "custom"; // default: "app" (follows app theme)
+  startingDir: "workspace" | string; // default: "workspace" (workspace root)
+  followActivePath: boolean; // default: false
+  scrollbackLines: number; // default: 10_000
+}
+
+export const DEFAULTS: TerminalConfig = {
+  shell: "",
+  fontSize: 13,
+  fontFamily: "monospace",
+  theme: "app",
+  startingDir: "workspace",
+  followActivePath: false,
+  scrollbackLines: 10_000,
+};
+
+/**
+ * Read a typed TerminalConfig from the raw context.config record,
+ * falling back to defaults for missing / mistyped values.
+ */
+export function resolveConfig(raw: Record<string, unknown>): TerminalConfig {
+  return {
+    shell: typeof raw.shell === "string" ? raw.shell : DEFAULTS.shell,
+    fontSize: typeof raw.fontSize === "number" && raw.fontSize > 0 ? raw.fontSize : DEFAULTS.fontSize,
+    fontFamily: typeof raw.fontFamily === "string" && raw.fontFamily.length > 0 ? raw.fontFamily : DEFAULTS.fontFamily,
+    theme: isValidTheme(raw.theme) ? raw.theme : DEFAULTS.theme,
+    startingDir: typeof raw.startingDir === "string" && raw.startingDir.length > 0 ? raw.startingDir : DEFAULTS.startingDir,
+    followActivePath: typeof raw.followActivePath === "boolean" ? raw.followActivePath : DEFAULTS.followActivePath,
+    scrollbackLines:
+      typeof raw.scrollbackLines === "number" && raw.scrollbackLines > 0
+        ? raw.scrollbackLines
+        : DEFAULTS.scrollbackLines,
+  };
+}
+
+function isValidTheme(v: unknown): v is TerminalConfig["theme"] {
+  return v === "app" || v === "dark" || v === "light" || v === "custom";
+}
+
+// ---------------------------------------------------------------------------
+// xterm theme helpers
+// ---------------------------------------------------------------------------
+
+const DARK_THEME: ITheme = {
+  background: "#1e1e1e",
+  foreground: "#d4d4d4",
+  cursor: "#d4d4d4",
+  cursorAccent: "#1e1e1e",
+  selectionBackground: "#264f78",
+};
+
+const LIGHT_THEME: ITheme = {
+  background: "#ffffff",
+  foreground: "#333333",
+  cursor: "#333333",
+  cursorAccent: "#ffffff",
+  selectionBackground: "#add6ff",
+  selectionForeground: "#333333",
+};
+
+/**
+ * Map the config theme mode + current app theme to an xterm ITheme.
+ * `custom` currently falls back to the dark palette.
+ */
+export function resolveXtermTheme(
+  themeMode: TerminalConfig["theme"],
+  appTheme: "light" | "dark",
+): ITheme {
+  const effective = themeMode === "app" ? appTheme : themeMode === "custom" ? "dark" : themeMode;
+  return effective === "light" ? { ...LIGHT_THEME } : { ...DARK_THEME };
+}
+
+/** Background colour matching the resolved xterm theme. */
+export function resolveBackground(
+  themeMode: TerminalConfig["theme"],
+  appTheme: "light" | "dark",
+): string {
+  const effective = themeMode === "app" ? appTheme : themeMode === "custom" ? "dark" : themeMode;
+  return effective === "light" ? "#ffffff" : "#1e1e1e";
+}

--- a/packages/terminal/src/manifest.ts
+++ b/packages/terminal/src/manifest.ts
@@ -6,7 +6,7 @@ export const manifest: PluginManifest = {
   version: "0.0.1",
   description: "Full PTY terminal",
   icon: ">_",
-  requiredCapabilities: ["pty"],
+  requiredCapabilities: ["pty", "fs:read"],
 };
 
 export default manifest;

--- a/packages/terminal/src/shells.ts
+++ b/packages/terminal/src/shells.ts
@@ -1,0 +1,32 @@
+import { readTextFile } from "@origin-cards/sdk";
+
+const FALLBACK_SHELLS = ["/bin/zsh", "/bin/bash", "/bin/sh"];
+
+let cached: string[] | null = null;
+
+/**
+ * Detect available shells by reading `/etc/shells`.
+ *
+ * Uses the SDK `readTextFile` helper which proxies through the host's
+ * Tauri fs plugin. Falls back to a hardcoded list on error.
+ *
+ * NOTE: If a dedicated Rust command (e.g. `list_shells`) is added to
+ * the host, this can be replaced with `invoke("list_shells")`.
+ */
+export async function detectShells(): Promise<string[]> {
+  if (cached) return cached;
+
+  try {
+    const content = await readTextFile("/etc/shells");
+    const shells = content
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0 && !line.startsWith("#"));
+
+    cached = shells.length > 0 ? shells : FALLBACK_SHELLS;
+  } catch {
+    cached = FALLBACK_SHELLS;
+  }
+
+  return cached;
+}


### PR DESCRIPTION
## Summary

Implements #6 — each terminal card now has configurable settings persisted to `context.config` (workspace store).

## Config schema

| Field | Type | Default | Notes |
|-------|------|---------|-------|
| `shell` | `string` | `""  ` (system default) | Detected from `/etc/shells` |
| `fontSize` | `number` | `13` | Live-updated |
| `fontFamily` | `string` | `"monospace"` | Live-updated |
| `theme` | `'app' \| 'dark' \| 'light' \| 'custom'` | `'app'` | Live-updated |
| `startingDir` | `'workspace' \| string` | `'workspace'` | Requires restart |
| `followActivePath` | `boolean` | `false` | Auto-cd on active file change |
| `scrollbackLines` | `number` | `10000` | Live-updated |

## What's included

- **`config.ts`** — `TerminalConfig` type, defaults, `resolveConfig()` helper, xterm theme mapping
- **`shells.ts`** — Detects available shells by reading `/etc/shells` via SDK `readTextFile`; falls back to `[/bin/zsh, /bin/bash, /bin/sh]`
- **`TerminalConfigPanel.tsx`** — Settings panel with inline styles (no Tailwind dependency); shell dropdown, font/theme/CWD inputs, follow-path toggle, scrollback input, restart button
- **`TerminalPlugin.tsx`** — Refactored to use config:
  - Terminal created with config values on mount
  - Separate `useEffect` hooks for dynamic updates (font, theme, scrollback) without PTY restart
  - `restartKey` state for explicit PTY restart on shell/CWD change
  - `followActivePath` via `useBusChannel("origin:workspace/active-path")`
  - Gear icon overlay (top-right) toggles config panel
- **`manifest.ts`** — Added `fs:read` to `requiredCapabilities`
- **`.gitignore`** — Added `*.tsbuildinfo`

## Notes

- Shell detection uses `readTextFile("/etc/shells")` via the SDK fs proxy. If a dedicated Rust command (`list_shells`) is added to the host, the detection can be swapped to `invoke("list_shells")`.
- The `custom` theme option currently falls back to the dark palette — a custom color picker can be added in a follow-up.
- `shell` and `cwd` are passed to `pty_spawn` — the host-side Rust PTY handler needs to accept these params (no-op if unsupported yet).

Closes #6

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin-plugin-monorepo/9?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->