### PR TITLE
feat(terminal): bus integration — follow active path + publish CWD via OSC 7

### DIFF
--- a/packages/api/src/plugin.ts
+++ b/packages/api/src/plugin.ts
@@ -26,6 +26,16 @@ export interface OriginChannelMap {
     /** Plugin ID of the publisher, e.g. "com.origin.filetree". */
     source: string;
   };
+  /**
+   * Published by the terminal plugin when the shell's current working
+   * directory changes, detected via OSC 7 escape sequences.
+   */
+  "com.origin.terminal:cwd": {
+    /** Absolute filesystem path of the current working directory. */
+    path: string;
+    /** Card ID of the terminal instance that published the event. */
+    cardId: string;
+  };
 }
 
 /** Pub/sub bus injected into every plugin via PluginContext. */

--- a/packages/terminal/src/TerminalPlugin.tsx
+++ b/packages/terminal/src/TerminalPlugin.tsx
@@ -10,8 +10,8 @@
 //     in origin/; when it is, this plugin will receive live PTY output without
 //     any changes here.
 
-import { useEffect, useRef } from "react";
-import { invoke, onEvent } from "@origin-cards/sdk";
+import { useEffect, useRef, useCallback } from "react";
+import { invoke, onEvent, useBusChannel } from "@origin-cards/sdk";
 import type { IframePluginContextWithConfig } from "@origin-cards/sdk";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
@@ -19,8 +19,77 @@ import { WebglAddon } from "@xterm/addon-webgl";
 import { ClipboardAddon } from "@xterm/addon-clipboard";
 import "@xterm/xterm/css/xterm.css";
 
+import { resolveConfig } from "./config";
+import { parseOsc7Cwd } from "./osc7";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Extract the parent directory from a path. */
+function dirname(path: string): string {
+  const sep = path.includes("\\") ? "\\" : "/";
+  const parts = path.split(sep);
+  parts.pop();
+  return parts.join(sep) || sep;
+}
+
+// ---------------------------------------------------------------------------
+// xterm theme helpers
+// ---------------------------------------------------------------------------
+
+const DARK_THEME = {
+  background: "#1e1e1e",
+  foreground: "#d4d4d4",
+  cursor: "#d4d4d4",
+  cursorAccent: "#1e1e1e",
+  selectionBackground: "#264f78",
+};
+
+const LIGHT_THEME = {
+  background: "#ffffff",
+  foreground: "#333333",
+  cursor: "#333333",
+  cursorAccent: "#ffffff",
+  selectionBackground: "#add6ff",
+  selectionForeground: "#333333",
+};
+
+function resolveXtermTheme(appTheme: "light" | "dark") {
+  return appTheme === "light" ? { ...LIGHT_THEME } : { ...DARK_THEME };
+}
+
+function resolveBackground(appTheme: "light" | "dark"): string {
+  return appTheme === "light" ? "#ffffff" : "#1e1e1e";
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
 export default function TerminalPlugin({ context }: { context: IframePluginContextWithConfig }) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const termRef = useRef<Terminal | null>(null);
+
+  // Resolve typed config from the raw context.config record.
+  const config = resolveConfig(context.config);
+  const configRef = useRef(config);
+  configRef.current = config;
+
+  // ------------------------------------------------------------------
+  // Bus: publish CWD changes
+  // ------------------------------------------------------------------
+
+  const publishCwd = useBusChannel("com.origin.terminal:cwd");
+  const publishCwdRef = useRef(publishCwd);
+  publishCwdRef.current = publishCwd;
+
+  // Track the last published CWD to avoid duplicate publishes.
+  const lastCwdRef = useRef<string | null>(null);
+
+  // ------------------------------------------------------------------
+  // Terminal lifecycle — create / destroy
+  // ------------------------------------------------------------------
 
   useEffect(() => {
     const container = containerRef.current;
@@ -29,7 +98,7 @@ export default function TerminalPlugin({ context }: { context: IframePluginConte
     const term = new Terminal({
       fontFamily: "monospace",
       fontSize: 13,
-      theme: { background: "#1e1e1e" },
+      theme: resolveXtermTheme(context.theme),
       cursorBlink: true,
     });
 
@@ -45,13 +114,28 @@ export default function TerminalPlugin({ context }: { context: IframePluginConte
     term.open(container);
     fitAddon.fit();
 
+    termRef.current = term;
+
     const { cols, rows } = term;
 
     // Subscribe to PTY data stream via the SDK event bridge.
     // The host proxies pty:data events from the Rust PTY channel.
+    //
+    // Data passes through the OSC 7 parser to detect CWD changes. The raw
+    // bytes are decoded to a string for parsing, then written to xterm as
+    // a Uint8Array (xterm handles its own decoding internally).
     const unsubPty = onEvent("pty:data", { id: context.cardId }, (payload) => {
       const data = (payload as { data: number[] }).data;
-      term.write(new Uint8Array(data));
+      const bytes = new Uint8Array(data);
+      term.write(bytes);
+
+      // Parse OSC 7 to detect CWD changes.
+      const text = new TextDecoder().decode(bytes);
+      const cwd = parseOsc7Cwd(text);
+      if (cwd && cwd !== lastCwdRef.current) {
+        lastCwdRef.current = cwd;
+        publishCwdRef.current({ path: cwd, cardId: context.cardId });
+      }
     });
 
     term.onData((data) => {
@@ -87,12 +171,52 @@ export default function TerminalPlugin({ context }: { context: IframePluginConte
       if (resizeTimer) clearTimeout(resizeTimer);
       ro.disconnect();
       unsubPty();
+      termRef.current = null;
       term.dispose();
       invoke("pty_destroy", { id: context.cardId }).catch(console.error);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [context.cardId]);
 
+  // ------------------------------------------------------------------
+  // Bus: theme-changed — update xterm theme dynamically
+  // ------------------------------------------------------------------
+
+  useBusChannel("com.origin.app:theme-changed", useCallback((payload: unknown) => {
+    const term = termRef.current;
+    if (!term) return;
+    const { theme } = payload as { theme: "light" | "dark" };
+    term.options.theme = resolveXtermTheme(theme);
+  }, []));
+
+  // ------------------------------------------------------------------
+  // Bus: follow active path — cd when workspace active path changes
+  // ------------------------------------------------------------------
+
+  const handleActivePath = useCallback(
+    (payload: unknown) => {
+      if (!configRef.current.followActivePath) return;
+      const { path, type } = payload as { path: string; type: "file" | "directory" };
+      const dir = type === "directory" ? path : dirname(path);
+      // Escape single quotes in the path for safe shell interpolation.
+      const escaped = dir.replace(/'/g, "'\\''");
+      invoke("pty_write", {
+        id: context.cardId,
+        data: Array.from(new TextEncoder().encode(`cd '${escaped}'\n`)),
+      }).catch(console.error);
+    },
+    [context.cardId],
+  );
+
+  useBusChannel("origin:workspace/active-path", handleActivePath);
+
+  // ------------------------------------------------------------------
+  // Render
+  // ------------------------------------------------------------------
+
+  const bg = resolveBackground(context.theme);
+
   return (
-    <div ref={containerRef} style={{ width: "100%", height: "100%", background: "#1e1e1e" }} />
+    <div ref={containerRef} style={{ width: "100%", height: "100%", background: bg }} />
   );
 }

--- a/packages/terminal/src/config.ts
+++ b/packages/terminal/src/config.ts
@@ -1,0 +1,22 @@
+/** Per-card terminal configuration persisted to context.config. */
+export interface TerminalConfig {
+  /** Whether to cd when the workspace active path changes. Default: false. */
+  followActivePath: boolean;
+}
+
+export const DEFAULTS: TerminalConfig = {
+  followActivePath: false,
+};
+
+/**
+ * Read a typed TerminalConfig from the raw context.config record,
+ * falling back to defaults for missing / mistyped values.
+ */
+export function resolveConfig(raw: Record<string, unknown>): TerminalConfig {
+  return {
+    followActivePath:
+      typeof raw.followActivePath === "boolean"
+        ? raw.followActivePath
+        : DEFAULTS.followActivePath,
+  };
+}

--- a/packages/terminal/src/osc7.ts
+++ b/packages/terminal/src/osc7.ts
@@ -1,0 +1,30 @@
+/**
+ * OSC 7 escape sequence parser.
+ *
+ * Shells (zsh natively, bash via PROMPT_COMMAND) emit OSC 7 to report the
+ * current working directory after every command:
+ *
+ *   ESC ] 7 ; file://hostname/path ST
+ *
+ * Where ST is either BEL (0x07) or ESC \ (0x1b 0x5c).
+ */
+
+const OSC7_RE = /\x1b\]7;file:\/\/[^/]*([^\x07\x1b]*?)(?:\x07|\x1b\\)/g;
+
+/**
+ * Extract the last CWD path from a chunk of terminal data that may contain
+ * one or more OSC 7 sequences. Returns the decoded path or `null`.
+ */
+export function parseOsc7Cwd(data: string): string | null {
+  let last: string | null = null;
+  let m: RegExpExecArray | null;
+  OSC7_RE.lastIndex = 0;
+  while ((m = OSC7_RE.exec(data)) !== null) {
+    try {
+      last = decodeURIComponent(m[1]);
+    } catch {
+      last = m[1];
+    }
+  }
+  return last;
+}


### PR DESCRIPTION
## Summary

Terminal plugin now participates in the Origin bus system for two-way sync with other plugins.

## Changes

### Subscribe: `origin:workspace/active-path`
When a directory is selected in filetree (or any publisher), the terminal `cd`s to that path. Gated by `followActivePath` per-card config toggle (default `false`).

### Subscribe: `com.origin.app:theme-changed`
Updates xterm theme dynamically without re-mounting the terminal instance.

### Publish: `com.origin.terminal:cwd`
Parses OSC 7 escape sequences from PTY output to detect CWD changes. Publishes on the bus so filetree and other plugins can sync to where the terminal is.

### New channel type
Added `com.origin.terminal:cwd` to `OriginChannelMap` in `@origin-cards/api`:
```ts
"com.origin.terminal:cwd": { path: string; cardId: string };
```

### Config
- `followActivePath: boolean` — per-card toggle, default `false`
- New `config.ts` with typed config resolution
- New `osc7.ts` parser module (separated for testability)

## Files changed
- `packages/api/src/plugin.ts` — add channel type
- `packages/terminal/src/TerminalPlugin.tsx` — bus subscriptions + CWD publishing
- `packages/terminal/src/config.ts` — new config type + resolver
- `packages/terminal/src/osc7.ts` — new OSC 7 parser

## Verification
- `npm run build --workspace packages/api` ✅
- `npm run build --workspace packages/terminal` ✅
- `tsc --build packages/api/tsconfig.json packages/terminal/tsconfig.json` ✅ (clean)

closes #4

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin-plugin-monorepo/10?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->