### PR TITLE
docs: clarify this repo is the canonical external plugin starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # origin-plugin-monorepo
 
-The official plugin collection for [Origin](https://github.com/fellanH/origin) — and the starting point for building your own.
+The official plugin collection for [Origin](https://github.com/fellanH/origin) — and the **canonical starting point for external plugin development**.
+
+If you want to build a plugin for Origin, **start here**. Clone this repo, copy `packages/template`, and follow the [Getting started](#getting-started) instructions below.
+
+> **Note — origin/packages/template/**
+> The main Origin repo contains a minimal in-tree template at [`packages/template/`](https://github.com/fellanH/origin/tree/main/packages/template). That template is an internal reference used by the Origin core team and does not include the full development tooling (DevShell, watch-install, mock PluginContext) provided by this repo. External plugin authors should always use this monorepo as their starting point. See [fellanH/origin#122](https://github.com/fellanH/origin/issues/122) for background.
 
 ## Packages
 


### PR DESCRIPTION
## Summary

- Explicitly states this monorepo is the **canonical starting point** for external plugin development
- Adds a note explaining that `origin/packages/template/` is the internal in-tree reference and does not include full dev tooling (DevShell, watch-install, mock PluginContext)
- Links to fellanH/origin#122 for background

## Verification

- `npm run build` — ✅ all packages built
- `npm run typecheck` — pre-existing errors in `packages/monaco` (unrelated, same on `main`)
- `npm run lint` — no eslint config present (pre-existing, same on `main`)
- Change is documentation-only (README.md)

closes #1

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin-plugin-monorepo/11?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->